### PR TITLE
breaking: update konserve

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,8 @@ pom.xml.asc
 .nrepl-port
 .cpcache/
 temp/
-datahike.mv.db
+*.mv.db
+*.trace.db
 .idea/
 datahike-jdbc.iml
 .clj-kondo/

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ It is also possible to pass a configuration url via `:jdbcUrl` like it is mentio
 
 Arguments not mentioned will be passed downstream to the corresponding jdbc-driver so every configuration option available should be working.
 
+BREAKING CHANGE: datahike-jdbc versions after 0.1.45 no longer include actual JDBC drivers. Before you upgrade please make sure your application provides the necessary dependencies.
+
 ## Prerequisites
 For this backend to work you need to choose a database that is supported by JDBC. Please have a
 look at the docs for [clojure.java.jdbc](https://github.com/clojure/java.jdbc/). For the sake
@@ -51,6 +53,7 @@ On your local machine your setup prerequisites could look something like this:
 2. A running instance of PostgreSQL that you can connect to.
 3. [A JDK to run your Clojure on](https://clojure.org/guides/getting_started)
 4. [Leiningen, Boot or Clojure CLI to run your code or a REPL](https://leiningen.org/#install)
+5. The JDBC drivers you wish to use added as a dependency (since `0.2.x`)
 
 We will stick with Leiningen for this manual. If you want to use MySQL or H2 for a try, please
 have a look into the tests to see how to configure these backend stores.
@@ -83,6 +86,7 @@ keyword `:jdbc`. If you want to use other backends than JDBC please refer to the
                     :port 5432
                     :user "alice"
                     :password "foo"
+                    :table "my_first_application" ;; defaults to konserve
                     :dbname "config-test"}})
 
   ;; Create a database at this place, by default configuration we have a strict

--- a/build.clj
+++ b/build.clj
@@ -8,7 +8,7 @@
 (def org "replikativ")
 (def lib 'io.replikativ/datahike-jdbc)
 (def current-commit (b/git-process {:git-args "rev-parse HEAD"}))
-(def version (format "0.1.%s" (b/git-count-revs nil)))
+(def version (format "0.2.%s" (b/git-count-revs nil)))
 (def class-dir "target/classes")
 (def basis (b/create-basis {:project "deps.edn"}))
 (def jar-file (format "target/%s-%s.jar" (name lib) version))

--- a/deps.edn
+++ b/deps.edn
@@ -1,9 +1,15 @@
 {:deps {org.clojure/clojure         {:mvn/version "1.11.1" :scope "provided"}
-        io.replikativ/konserve-jdbc {:mvn/version "0.1.79"}}
+        io.replikativ/konserve-jdbc {:mvn/version "0.2.82"}
+        io.replikativ/datahike      {:mvn/version "0.6.1552" :scope "provided"}}
  :paths ["src"]
  :aliases {:test {:extra-paths ["test"]
-                  :extra-deps {lambdaisland/kaocha    {:mvn/version "1.84.1335"}
-                               io.replikativ/datahike {:mvn/version "0.6.1541"}}
+                  :extra-deps {lambdaisland/kaocha                {:mvn/version "1.84.1335"}
+                               com.h2database/h2                  {:mvn/version "2.1.214"}
+                               com.microsoft.sqlserver/mssql-jdbc {:mvn/version "9.4.1.jre11"}
+                               mysql/mysql-connector-java         {:mvn/version "8.0.25"}
+                               org.apache.derby/derby             {:mvn/version "10.16.1.1"}
+                               org.postgresql/postgresql          {:mvn/version "42.6.0"}
+                               org.xerial/sqlite-jdbc             {:mvn/version "3.41.2.2"}}
                   :main-opts ["-m" "kaocha.runner"]}
 
            :format {:extra-deps {cljfmt/cljfmt {:mvn/version "0.9.2"}}

--- a/src/datahike_jdbc/core.clj
+++ b/src/datahike_jdbc/core.clj
@@ -5,10 +5,10 @@
             [clojure.spec.alpha :as s]))
 
 (defmethod store-identity :jdbc [store-config]
-  (let [{:keys [jdbcUrl dbtype host port dbname]} store-config]
+  (let [{:keys [jdbcUrl dbtype host port dbname table]} store-config]
     (if jdbcUrl
-      [:jdbc jdbcUrl]
-      [:jdbc dbtype host port dbname])))
+      [:jdbc jdbcUrl table]
+      [:jdbc dbtype host port dbname table])))
 
 (defmethod empty-store :jdbc [store-config]
   (k/connect-store store-config))
@@ -36,6 +36,7 @@
 (s/def :datahike.store.jdbc/classname string?)
 (s/def :datahike.store.jdbc/user string?)
 (s/def :datahike.store.jdbc/password string?)
+(s/def :datahike.store.jdbc/table string?)
 (s/def ::jdbc (s/keys :req-un [:datahike.store.jdbc/backend]
                       :opt-un [:datahike.store.jdbc/dbtype
                                :datahike.store.jdbc/jdbcUrl
@@ -46,7 +47,8 @@
                                :datahike.store.jdbc/port
                                :datahike.store.jdbc/classname
                                :datahike.store.jdbc/user
-                               :datahike.store.jdbc/password]))
+                               :datahike.store.jdbc/password
+                               :datahike.store.jdbc/table]))
 
 (defmethod config-spec :jdbc [_] ::jdbc)
 


### PR DESCRIPTION
This enables multitenancy and unbundles the jdbc drivers from the library similar to `konserve`
The table name is also now included in the store signature. 