### PR TITLE
update store-identity to correctly determine equivalence of configs

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -8,7 +8,7 @@
 (def org "replikativ")
 (def lib 'io.replikativ/datahike-jdbc)
 (def current-commit (b/git-process {:git-args "rev-parse HEAD"}))
-(def version (format "0.2.%s" (b/git-count-revs nil)))
+(def version (format "0.3.%s" (b/git-count-revs nil)))
 (def class-dir "target/classes")
 (def basis (b/create-basis {:project "deps.edn"}))
 (def jar-file (format "target/%s-%s.jar" (name lib) version))

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:deps {org.clojure/clojure         {:mvn/version "1.11.1" :scope "provided"}
         io.replikativ/konserve-jdbc {:mvn/version "0.2.82"}
-        io.replikativ/datahike      {:mvn/version "0.6.1552" :scope "provided"}}
+        io.replikativ/datahike      {:mvn/version "0.6.1554" :scope "provided"}}
  :paths ["src"]
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {lambdaisland/kaocha                {:mvn/version "1.84.1335"}

--- a/src/datahike_jdbc/core.clj
+++ b/src/datahike_jdbc/core.clj
@@ -2,28 +2,39 @@
   (:require [datahike.store :refer [empty-store delete-store connect-store default-config config-spec release-store store-identity]]
             [datahike.config :refer [map-from-env]]
             [konserve-jdbc.core :as k]
-            [clojure.spec.alpha :as s]))
+            [next.jdbc.connection :as connection]
+            [clojure.spec.alpha :as s]
+            [clojure.string :as str]))
+
+(defn prepare-config [cfg]
+  ;; next.jdbc does not officially support the credentials in the format: driver://user:password@host/db
+  ;; connection/uri->db-spec makes is possible but is rough around the edges
+  ;; https://github.com/seancorfield/next-jdbc/issues/229
+  (if (contains? cfg :jdbcUrl)
+    (-> cfg :jdbcUrl connection/uri->db-spec
+        (update :dbtype #(str/replace % #"postgres$" "postgresql"))
+        (update :port #(if (pos? %) % (-> connection/dbtypes (get (:dbtype %)) :port))))
+    cfg))
 
 (defmethod store-identity :jdbc [store-config]
-  (let [{:keys [jdbcUrl dbtype host port dbname table]} store-config]
-    (if jdbcUrl
-      [:jdbc jdbcUrl table]
-      [:jdbc dbtype host port dbname table])))
+  ;; the store signature is made up of the dbtype, dbname, and table
+  (let [{:keys [dbtype _host _port dbname table]} (prepare-config store-config)]
+    [:jdbc dbtype dbname table]))
 
 (defmethod empty-store :jdbc [store-config]
-  (k/connect-store store-config))
+  (k/connect-store (prepare-config store-config)))
 
 (defmethod delete-store :jdbc [store-config]
-  (k/delete-store store-config))
+  (k/delete-store (prepare-config store-config)))
 
 (defmethod connect-store :jdbc [store-config]
-  (k/connect-store store-config))
+  (k/connect-store (prepare-config store-config)))
 
 (defmethod default-config :jdbc [config]
-  (merge
-   (map-from-env :datahike-store-config {:dbtype "h2:mem"
-                                         :dbname "datahike"})
-   config))
+  ;; with the introduction of the store-identity config data should derived from inputs and not set to default values
+  (let [env-config (prepare-config (map-from-env :datahike-store-config {}))
+        passed-config (prepare-config config)]
+    (merge env-config passed-config)))
 
 (s/def :datahike.store.jdbc/backend #{:jdbc})
 (s/def :datahike.store.jdbc/dbtype #{"h2" "h2:mem" "hsqldb" "jtds:sqlserver" "mysql" "oracle:oci" "oracle:thin" "postgresql" "redshift" "sqlite" "sqlserver"})

--- a/src/datahike_jdbc/core.clj
+++ b/src/datahike_jdbc/core.clj
@@ -11,9 +11,11 @@
   ;; connection/uri->db-spec makes is possible but is rough around the edges
   ;; https://github.com/seancorfield/next-jdbc/issues/229
   (if (contains? cfg :jdbcUrl)
-    (-> cfg :jdbcUrl connection/uri->db-spec
-        (update :dbtype #(str/replace % #"postgres$" "postgresql"))
-        (update :port #(if (pos? %) % (-> connection/dbtypes (get (:dbtype %)) :port))))
+    (merge
+     (dissoc cfg :jdbcUrl)
+     (-> cfg :jdbcUrl connection/uri->db-spec
+         (update :dbtype #(str/replace % #"postgres$" "postgresql"))
+         (update :port #(if (pos? %) % (-> connection/dbtypes (get (:dbtype %)) :port)))))
     cfg))
 
 (defmethod store-identity :jdbc [store-config]

--- a/test/datahike_jdbc/core_test.cljc
+++ b/test/datahike_jdbc/core_test.cljc
@@ -190,15 +190,23 @@
                         :host "localhost"
                         :dbname "config-test"
                         :user "alice"
-                        :password "foo"}
+                        :password "foo"
+                        :table "samezies"}
                 :schema-flexibility :read
                 :keep-history? false}
         config2 {:store {:backend :jdbc
-                         :jdbcUrl "postgresql://alice:foo@localhost/config-test"}
+                         :jdbcUrl "postgresql://alice:foo@localhost/config-test"
+                         :table "samezies"}
                  :schema-flexibility :read
                  :keep-history? false}
         config3 {:store {:backend :jdbc
-                         :jdbcUrl "postgresql://alice:foo@127.0.0.1/config-test"}
+                         :jdbcUrl "postgresql://alice:foo@127.0.0.1/config-test"
+                         :table "samezies"}
+                 :schema-flexibility :read
+                 :keep-history? false}
+        config4 {:store {:backend :jdbc
+                         :jdbcUrl "postgresql://alice:foo@127.0.0.1/config-test"
+                         :table "different"}
                  :schema-flexibility :read
                  :keep-history? false}
         _ (d/delete-database config)]
@@ -207,6 +215,7 @@
           conn (d/connect config)
           conn2 (d/connect config2)
           conn3 (d/connect config2)]
+      (is (not (d/database-exists? config4)))
 
       (d/transact conn [{:db/id 1, :name  "Ivan", :age   15}
                         {:db/id 2, :name  "Petr", :age   37}


### PR DESCRIPTION
The store-identity is not correctly determining if configurations are equivalent. As a result two stores are functionally equivalent are not be deemed so unless they are literally equivalent. This fix uses the store-identity to check equivalence for configurations and connections. It also prevents defaults that may make stores different without the user's knowledge.

e.g. on JDBC these two stores are equivalent but not be deemed so. They appear different as because in one case the DB and datahike are on the same network and the in the other they are not.

```
(def pg-cfg  {:dbtype  "postgresql" :jdbcUrl "postgresql://user:password@localhost/konserve"}
```

```
(def pg-cfg  {:dbtype  "postgresql" :jdbcUrl "postgresql://user:password@myremoteaddress.com/konserve"})
```