### PR TITLE
generate signature but leave jdbc url untouched

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:deps {org.clojure/clojure         {:mvn/version "1.11.1" :scope "provided"}
-        io.replikativ/konserve-jdbc {:mvn/version "0.2.82"}
+        io.replikativ/konserve-jdbc {:mvn/version "0.2.84"}
         io.replikativ/datahike      {:mvn/version "0.6.1554" :scope "provided"}}
  :paths ["src"]
  :aliases {:test {:extra-paths ["test"]


### PR DESCRIPTION
The last release of [konserve](https://github.com/replikativ/konserve-jdbc/pull/21) allows `url` parameters to be passed to `next.jdbc` this update allows prevents `datahike` from blocking those parameters. This is critical for compatibility `jdbc` databases the require additional parameter. e.g `fly.io` which requires `?sslmode=disable`